### PR TITLE
upd: don't omit coverage of test files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ where = ["src"]
 branch = true
 omit = [
     # Omit test directory
-    "./tests/*"
+    #"./tests/*"
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
**DESCRIPTION:** This PR removes `tests` path from the `tool.coverage.run` `omit` parameter. It's important to know if tests are also properly run and all possible branches are covered.