### PR TITLE
Fix/summary report/bad date parsing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ on:
     branches:
       - main
       - 'feat/**'
+      - 'fix/**'
     # Trigger workflow on tag push explicitly
     tags:
       - 'v*.*.*'  # trigger only on tags for releases

--- a/src/woffu_client/woffu_api_client.py
+++ b/src/woffu_client/woffu_api_client.py
@@ -641,7 +641,7 @@ diarysummaries/{diary_summary_id}/workday/slots/self",
     def _get_slot_hours(self, slot: dict, date: str) -> float:
         """Return the hours for a single slot, using motive if available."""
         if slot and slot.get("motive"):
-            return slot["motive"]["hours"]
+            return slot["motive"]["trueHours"]
 
         logger.info(
             f"Slot of date {date} doesn't have motive. \

--- a/src/woffu_client/woffu_api_client.py
+++ b/src/woffu_client/woffu_api_client.py
@@ -644,7 +644,7 @@ diarysummaries/{diary_summary_id}/workday/slots/self",
             return slot["motive"]["hours"]
 
         logger.info(
-            f"Slot of date {date} doesn't have motive.\
+            f"Slot of date {date} doesn't have motive. \
 Using `in`/`out` keys...",
         )
         return self._calculate_hours_from_in_out(slot)
@@ -670,10 +670,17 @@ Using `in`/`out` keys...",
     def _parse_datetime(self, date_str: str, utc_offset: str) -> datetime:
         """Parse date string and UTC offset safely into datetime."""
         date_timezoned = f"{date_str}{utc_offset.zfill(3)}00"
-        return datetime.strptime(
-            date_timezoned,
-            f"{DEFAULT_DATE_FORMAT}T%H:%M:%S%z",
-        )
+        try:
+            return datetime.strptime(
+                date_timezoned,
+                f"{DEFAULT_DATE_FORMAT}T%H:%M:%S%z",
+            )
+        except Exception as e:
+            logger.debug(f"Date with milliseconds. {e}")
+            return datetime.strptime(
+                date_timezoned,
+                f"{DEFAULT_DATE_FORMAT}T%H:%M:%S.%f%z",
+            )
 
     def _aggregate_hour_types(
         self, event_report: dict,

--- a/tests/test_woffu_api_client.py
+++ b/tests/test_woffu_api_client.py
@@ -767,6 +767,42 @@ class TestWoffuAPISummaryDiary(BaseWoffuAPITest):
         self.assertEqual(result, {})
 
     @patch.object(WoffuAPIClient, "_get_workday_slots")
+    def test_get_summary_report_slot_with_motive_computes_hours(
+        self, mock_slots,
+    ):
+        """get_summary_report computes hours from motive key."""
+        diary = {
+            "date": "2025-09-12",
+            "diarySummaryId": 1,
+            "diaryHourTypes": [],
+        }
+        mock_slots.return_value = [
+            {
+                "in": {
+                    "trueDate": "2025-09-12T12:00:00",
+                    "utcTime": "12:00:00 +01",
+                },
+                "out": {
+                    "trueDate": "2025-09-12T16:00:00.1",
+                    "utcTime": "16:00:00 +01",
+                },
+                "motive": {
+                    'agreementEventId': 913100,
+                    'hours': 9.47056,
+                    'isPresence': True,
+                    'name': 'Oficina/Office',
+                    'requestId': None,
+                    'trueHours': 2.745,
+                },
+            },
+        ]
+        with patch.object(self.client, "_get_presence", return_value=[diary]):
+            result = self.client.get_summary_report("2025-09-12", "2025-09-12")
+            self.assertAlmostEqual(
+                result["2025-09-12"]["work_hours"], 2.745,
+            )
+
+    @patch.object(WoffuAPIClient, "_get_workday_slots")
     def test_get_summary_report_slot_without_motive_computes_hours(
         self, mock_slots,
     ):

--- a/tests/test_woffu_api_client.py
+++ b/tests/test_woffu_api_client.py
@@ -783,14 +783,16 @@ class TestWoffuAPISummaryDiary(BaseWoffuAPITest):
                     "utcTime": "12:00:00 +01",
                 },
                 "out": {
-                    "trueDate": "2025-09-12T16:00:00",
+                    "trueDate": "2025-09-12T16:00:00.1",
                     "utcTime": "16:00:00 +01",
                 },
             },
         ]
         with patch.object(self.client, "_get_presence", return_value=[diary]):
             result = self.client.get_summary_report("2025-09-12", "2025-09-12")
-            self.assertAlmostEqual(result["2025-09-12"]["work_hours"], 4)
+            self.assertAlmostEqual(
+                result["2025-09-12"]["work_hours"], 4.0000277777777775,
+            )
 
     @patch.object(WoffuAPIClient, "_get_presence")
     @patch.object(WoffuAPIClient, "_get_workday_slots")


### PR DESCRIPTION
**DESCRIPTION:** This PR addresses the following problems:
- `in` and `out` dates not being properly parsed when having milliseconds,
- Wrong total hours key used when getting the `motive` key (`trueHours` is the correct one).

**RELATED ISSUES:**
- Closes #27 