### PR TITLE
fix: bad hours computing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,7 +95,7 @@ jobs:
           pip install ".[dev]"
 
       - name: Set runner timezone
-        run: sudo timedatectl set-timezone Europe/Madrid
+        run: timedatectl set-timezone Europe/Madrid
 
       - name: Verify runner's timezone
         run: date
@@ -135,7 +135,7 @@ jobs:
         with:
           name: coverage
           path: coverage
-      - uses: SonarSource/sonarqube-scan-action@v5
+      - uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,9 +94,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install ".[dev]"
 
-      - name: Set runner timezone
-        run: timedatectl set-timezone Europe/Madrid
-
       - name: Verify runner's timezone
         run: date
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,6 +94,16 @@ jobs:
           python -m pip install --upgrade pip
           pip install ".[dev]"
 
+      - name: Set runner timezone
+        uses: szenius/set-timezone@v2.0
+        with:
+          timezoneLinux: "Europe/Madrid"
+          timezoneMacos: "Europe/Madrid"
+          timezoneWindows: "Romance Standard Time"
+
+      - name: Verify runner's timezone
+        run: date
+
       - name: Run tests
         run: pytest -v --maxfail=1 --disable-warnings --junitxml coverage/report.xml --cov-report term --cov-report xml:coverage/coverage.xml --cov=. tests
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,17 +94,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install ".[dev]"
 
-      - name: Configure timezone
-        run: |
-          sudo ln -snf /usr/share/zoneinfo/Europe/Madrid /etc/localtime
-          echo "Europe/Madrid" | sudo tee /etc/timezone
-          date
-
-      - name: Verify runner's timezone
-        run: |
-          date
-          ls -l /etc/localtime
-
       - name: Run tests
         env:
           # Not required but explicitly defined to warn user that tests are executed in this timezone

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,15 +87,23 @@ jobs:
 
       - name: Install OS dependencies
         run: |
-          apt-get update && apt-get install -y sqlite3
+          apt-get update && apt-get install -y sqlite3 tzdata
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install ".[dev]"
 
+      - name: Configure timezone
+        run: |
+          sudo ln -snf /usr/share/zoneinfo/Europe/Madrid /etc/localtime
+          echo "Europe/Madrid" | sudo tee /etc/timezone
+          date
+
       - name: Verify runner's timezone
-        run: date
+        run: |
+          date
+          ls -l /etc/localtime
 
       - name: Run tests
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,16 +95,14 @@ jobs:
           pip install ".[dev]"
 
       - name: Set runner timezone
-        uses: szenius/set-timezone@v2.0
-        with:
-          timezoneLinux: "Europe/Madrid"
-          timezoneMacos: "Europe/Madrid"
-          timezoneWindows: "Romance Standard Time"
+        run: sudo timedatectl set-timezone Europe/Madrid
 
       - name: Verify runner's timezone
         run: date
 
       - name: Run tests
+        env:
+          TZ: Europe/Madrid
         run: pytest -v --maxfail=1 --disable-warnings --junitxml coverage/report.xml --cov-report term --cov-report xml:coverage/coverage.xml --cov=. tests
 
       - name: Upload coverage reports - Only for Python 3.11

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Install OS dependencies
         run: |
-          apt-get update && apt-get install -y sqlite3 tzdata
+          apt-get update && apt-get install -y sqlite3
 
       - name: Install dependencies
         run: |
@@ -107,6 +107,7 @@ jobs:
 
       - name: Run tests
         env:
+          # Not required but explicitly defined to warn user that tests are executed in this timezone
           TZ: Europe/Madrid
         run: pytest -v --maxfail=1 --disable-warnings --junitxml coverage/report.xml --cov-report term --cov-report xml:coverage/coverage.xml --cov=. tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,15 +11,15 @@ authors = [{name="Marc Palacín Marfil", email="marc.palacin.marfil@gmail.com"}]
 readme = "README.md"
 license = {text = "MIT"}
 dependencies = [
-    "tzlocal==5.3.1"
+    "tzlocal==5.3.1",
+    "tzdata==2025.2"
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest==8.1.1",
     "pytest-cov==5.0.0",
-    "pre-commit==4.3.0",
-    "tzlocal==5.3.1"
+    "pre-commit==4.3.0"
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
 dev = [
     "pytest==8.1.1",
     "pytest-cov==5.0.0",
-    "pre-commit==4.3.0"
+    "pre-commit==4.3.0",
+    "tzlocal==5.3.1"
 ]
 
 

--- a/src/woffu_client/woffu_api_client.py
+++ b/src/woffu_client/woffu_api_client.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import sys
+import zoneinfo
 from datetime import datetime
 from datetime import timedelta
 from getpass import getpass
@@ -43,7 +44,14 @@ class WoffuAPIClient(Session):
 
     # Class arguments
     _woffu_api_url: str = "https://app.woffu.com"
-    _localzone = get_localzone()
+    try:
+        _localzone = get_localzone()
+    except zoneinfo.ZoneInfoNotFoundError:
+        # Fallback: use TZ environment variable if available
+        # - Workaround: Default to Europe/Madrid, this should be improved
+        #   knowing Woffu's issues with timezones
+        tzname = os.getenv("TZ", "Europe/Madrid")
+        _localzone = zoneinfo.ZoneInfo(tzname)
 
     hour_types_dict: dict = {5: "Extr. a compensar"}
 

--- a/src/woffu_client/woffu_api_client.py
+++ b/src/woffu_client/woffu_api_client.py
@@ -35,6 +35,7 @@ DEFAULT_DOCS_DIR = Path.home() / "Documents/woffu/docs"
 DEFAULT_SUMMARY_REPORTS_DIR = Path.home() / "Documents/woffu/summary_reports"
 
 DEFAULT_DATE_FORMAT = "%Y-%m-%d"
+UTC_OFFSET = "+0000"
 
 
 class WoffuAPIClient(Session):
@@ -443,7 +444,7 @@ diarysummaries/{diary_summary_id}/workday/slots/self",
                 # Split UtcTime and keep only the offset (format '+HHMM')
                 utc_offset = f"{utc_time.split(' ')[1].zfill(3)}00"
             except (IndexError, AttributeError):
-                utc_offset = "+0000"  # fallback to UTC
+                utc_offset = UTC_OFFSET  # fallback to UTC
 
             # WORKAROUND: Woffu stores incorrect UTC information
             # when signing in from the Webapp, showing same local date
@@ -452,7 +453,7 @@ diarysummaries/{diary_summary_id}/workday/slots/self",
             #   for any sign that comes with +0 in the UtcTime as we
             #   suspect Woffu DB is running on a server with the same
             #   local timezone as us.
-            if utc_offset == "+0000":
+            if utc_offset == UTC_OFFSET:
                 utc_offset = current_time.strftime("%z")
 
             sign_date_timezoned = f"{sign_date}{utc_offset}"
@@ -640,11 +641,11 @@ diarysummaries/{diary_summary_id}/workday/slots/self",
 
     def _get_slot_hours(self, slot: dict, date: str) -> float:
         """Return the hours for a single slot, using motive if available."""
-        if slot and slot.get("motive"):
+        if slot and slot.get("motive") and slot.get("motive") is not None:
             return slot["motive"]["trueHours"]
 
         logger.info(
-            f"Slot of date {date} doesn't have motive. \
+            f"Slot of date {date} doesn't have motive or is incomplete. \
 Using `in`/`out` keys...",
         )
         return self._calculate_hours_from_in_out(slot)
@@ -669,7 +670,24 @@ Using `in`/`out` keys...",
 
     def _parse_datetime(self, date_str: str, utc_offset: str) -> datetime:
         """Parse date string and UTC offset safely into datetime."""
-        date_timezoned = f"{date_str}{utc_offset.zfill(3)}00"
+        # Prepare current time with local timezone to use in case
+        # UTC offsets are wrong in Woffu.
+        # - We do it this way to take into account
+        #   Daylight Saving Timezones (CET +1, CEST +2, for example).
+        current_time = datetime.now(tz=self._localzone)
+
+        # WORKAROUND: Woffu stores incorrect UTC information
+        # when signing in from the Webapp, showing same local date
+        # on 'TrueDate' and 'UtcTime' but with no UTC offset (+0).
+        # - For the time being, we'll be using our local timezone
+        #   for any sign that comes with +0 in the UtcTime as we
+        #   suspect Woffu DB is running on a server with the same
+        #   local timezone as us.
+        utc_offset = f"{utc_offset.zfill(3)}00"
+        if utc_offset == UTC_OFFSET:
+            utc_offset = current_time.strftime("%z")
+
+        date_timezoned = f"{date_str}{utc_offset}"
         try:
             return datetime.strptime(
                 date_timezoned,

--- a/tests/test_woffu_api_client.py
+++ b/tests/test_woffu_api_client.py
@@ -875,6 +875,8 @@ class TestWoffuAPISummaryDiary(BaseWoffuAPITest):
         """get_summary_report computes hours even with an \
             invalid local timezone."""
         os.environ["TZ"] = "Bad/Timezone"
+        time.tzset()  # Apply timezone setting on Unix
+
         diary = {
             "date": "2025-09-30",
             "diarySummaryId": 1,
@@ -901,6 +903,7 @@ class TestWoffuAPISummaryDiary(BaseWoffuAPITest):
 
         # Restore environment value
         os.environ["TZ"] = "Europe/Madrid"
+        time.tzset()  # Apply timezone setting on Unix
 
     @patch.object(WoffuAPIClient, "_get_presence")
     @patch.object(WoffuAPIClient, "_get_workday_slots")


### PR DESCRIPTION
**DESCRIPTION:**
This PR addresses an issue when computing work hours from `in` and `out` keys. We were not taking into account Woffu's issue with incorrect UTC timezone assigned to non-naive datetimes.

**RELATED ISSUES:**
- Closes #30 