### PR TITLE
Feat/theoretical schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ actions:
     summary-report      Summary report of work hours for a given time window
 ```
 
+Each action might have its own arguments, check them by running:
+
+```bash
+woffu-cli <action-name> -h
+```
+
 ## Contributing
 
 ### GitFlow convention

--- a/src/woffu_client/cli.py
+++ b/src/woffu_client/cli.py
@@ -68,10 +68,16 @@ def main() -> None:
     )
 
     # ---- get_status ----
-    subparsers.add_parser(
+    status_parser = subparsers.add_parser(
         "get-status",
         help="Get current status and current day's \
             total amount of worked hours",
+    )
+
+    status_parser.add_argument(
+        "--extend",
+        action="store_true",
+        help="Shows additional info such as theoretical schedule.",
     )
 
     # ---- sign ----
@@ -89,7 +95,7 @@ def main() -> None:
             'in', 'out' or 'any' (default: 'any')",
     )
 
-    # ---- get_status ----
+    # ---- request_credentials ----
     subparsers.add_parser(
         "request-credentials",
         help="Request credentials from Woffu. For non-interactive sessions, \
@@ -97,7 +103,7 @@ def main() -> None:
                 WOFFU_USERNAME and WOFFU_PASSWORD.",
     )
 
-    # ---- get_status ----
+    # ---- summary_report ----
     summary_report_parser = subparsers.add_parser(
         "summary-report",
         help="Summary report of work hours for a given time window",
@@ -144,7 +150,7 @@ def main() -> None:
                 sys.exit(1)
         case "get-status":
             try:
-                client.get_status()
+                client.get_status(extend=args.extend)
             except Exception as e:
                 print(f"❌ Error retrieving status: {e}", file=sys.stderr)
         case "sign":

--- a/src/woffu_client/woffu_api_client.py
+++ b/src/woffu_client/woffu_api_client.py
@@ -417,20 +417,20 @@ diarysummaries/{diary_summary_id}/workday/slots/self",
         return {}
 
     def get_status(
-        self, only_running_clock: bool = False,
-    ) -> tuple[timedelta, bool]:
+        self, extend: bool = False, only_running_clock: bool = False,
+    ) -> tuple[timedelta, bool, timedelta]:
         """Return the total amount of worked hours and current sign status."""
         signs_in_day = self.get(url=f"{self._woffu_api_url}/api/signs").json()
 
         # Initialize a timer and the running clock boolean
-        total_time = timedelta()
-        running_clock = False
-
-        # Just return the las sign status
+        total_time: timedelta = timedelta()
+        running_clock: bool = False
+        theoretical_time: timedelta = timedelta()
+        # Just return the last sign status
         if only_running_clock:
             return total_time, (
                 signs_in_day[-1]["SignIn"] if signs_in_day else running_clock
-            )
+            ), theoretical_time
 
         # Go through all the signs.
         # Prepare current time with local timezone to use in case
@@ -485,7 +485,34 @@ diarysummaries/{diary_summary_id}/workday/slots/self",
         logger.info(
             f"You're currently signed {'in' if running_clock else 'out'}.",
         )
-        return total_time, running_clock
+
+        if extend:
+            # Retrieve theoretical schedule from presence query
+            presence = self._get_presence()
+            # Theoretical schedule
+            theoretical_schedule = presence[0]["workingTimeFormatted"]
+            # Theoretical schedule hours:
+            match theoretical_schedule['resource']:
+                case "_HoursMinutesFormatted":
+                    hours, minutes = theoretical_schedule['values']
+                    seconds = 0
+                    theoretical_time = timedelta(
+                        hours=int(hours),
+                        minutes=int(minutes),
+                        seconds=seconds,
+                    )
+                case _:
+                    logger.error(
+                        f"Invalid time format: \
+                            {theoretical_schedule['resource']}",
+                    )
+            logger.info(
+                "Theoretical schedule today: {:02d}:{:02d}:{:02d}".format(
+                    int(hours), int(minutes), int(seconds),
+                ),
+            )
+
+        return total_time, running_clock, theoretical_time
 
     def sign(self, type: str = "") -> HTTPResponse | None:
         """
@@ -496,7 +523,7 @@ diarysummaries/{diary_summary_id}/workday/slots/self",
             it will sign in/out without checking the current status.
         """
         # Get current sign status
-        _, signed_in = self.get_status(only_running_clock=True)
+        _, signed_in, _ = self.get_status(only_running_clock=True)
 
         # Evaluate current sign value against desired
         match type:
@@ -589,10 +616,28 @@ diarysummaries/{diary_summary_id}/workday/slots/self",
 
         return summary_report
 
+    def _flatten_working_time(self, time_formatted: dict) -> float:
+        """Return formatted times as float values."""
+        match time_formatted["resource"]:
+            case "_HoursMinutesFormatted":
+                return float(time_formatted["values"][0]) \
+                    + float(time_formatted["values"][1])/60
+            case _:
+                logger.error(
+                    f"Invalid time format resource: \
+{time_formatted['resource']}",
+                )
+                return -1.0
+
     def _build_event_report(self, diary: dict) -> dict:
         """Build the report for a single diary entry."""
         event_report: dict = {}
         diary_summary_id = diary["diarySummaryId"]
+
+        # Theoretical schedule
+        event_report["theoretical_schedule"] = self._flatten_working_time(
+            diary["workingTimeFormatted"],
+        )
 
         # Work hours from slots
         slots = self._get_workday_slots(diary_summary_id=diary_summary_id)

--- a/src/woffu_client/woffu_api_client.py
+++ b/src/woffu_client/woffu_api_client.py
@@ -490,27 +490,32 @@ diarysummaries/{diary_summary_id}/workday/slots/self",
             # Retrieve theoretical schedule from presence query
             presence = self._get_presence()
             # Theoretical schedule
-            theoretical_schedule = presence[0]["workingTimeFormatted"]
-            # Theoretical schedule hours:
-            match theoretical_schedule['resource']:
-                case "_HoursMinutesFormatted":
-                    hours, minutes = theoretical_schedule['values']
-                    seconds = 0
-                    theoretical_time = timedelta(
-                        hours=int(hours),
-                        minutes=int(minutes),
-                        seconds=seconds,
-                    )
-                case _:
-                    logger.error(
-                        f"Invalid time format: \
-                            {theoretical_schedule['resource']}",
-                    )
-            logger.info(
-                "Theoretical schedule today: {:02d}:{:02d}:{:02d}".format(
-                    int(hours), int(minutes), int(seconds),
-                ),
-            )
+            theoretical_schedule = presence[0].get("workingTimeFormatted", {})
+            if theoretical_schedule:
+                # Theoretical schedule hours:
+                match theoretical_schedule['resource']:
+                    case "_HoursMinutesFormatted":
+                        hours, minutes = theoretical_schedule['values']
+                        seconds = 0
+                        theoretical_time = timedelta(
+                            hours=int(hours),
+                            minutes=int(minutes),
+                            seconds=seconds,
+                        )
+                    case "_HoursFormatted":
+                        theoretical_time = timedelta(
+                            hours=int(theoretical_schedule['values'][0]),
+                        )
+                    case _:
+                        logger.error(
+                            f"Invalid time format: \
+                                {theoretical_schedule['resource']}",
+                        )
+                logger.info(
+                    "Theoretical schedule today: {:02d}:{:02d}:{:02d}".format(
+                        int(hours), int(minutes), int(seconds),
+                    ),
+                )
 
         return total_time, running_clock, theoretical_time
 
@@ -618,16 +623,23 @@ diarysummaries/{diary_summary_id}/workday/slots/self",
 
     def _flatten_working_time(self, time_formatted: dict) -> float:
         """Return formatted times as float values."""
-        match time_formatted["resource"]:
-            case "_HoursMinutesFormatted":
-                return float(time_formatted["values"][0]) \
-                    + float(time_formatted["values"][1])/60
-            case _:
-                logger.error(
-                    f"Invalid time format resource: \
-{time_formatted['resource']}",
-                )
-                return -1.0
+        if time_formatted:
+            time_format = time_formatted.get("resource", "")
+            match time_format:
+                case "_HoursMinutesFormatted":
+                    return float(time_formatted["values"][0]) \
+                        + float(time_formatted["values"][1])/60
+                case "_HoursFormatted":
+                    return float(time_formatted["values"][0])
+                case _:
+                    logger.error(
+                        f"Invalid time format resource: \
+    {time_formatted['resource']}",
+                    )
+                    return -1.0
+        else:
+            # Weekends don't have WorkingTimeFormatted key, return 0.0
+            return 0.0
 
     def _build_event_report(self, diary: dict) -> dict:
         """Build the report for a single diary entry."""
@@ -636,7 +648,7 @@ diarysummaries/{diary_summary_id}/workday/slots/self",
 
         # Theoretical schedule
         event_report["theoretical_schedule"] = self._flatten_working_time(
-            diary["workingTimeFormatted"],
+            diary.get("workingTimeFormatted", {}),
         )
 
         # Work hours from slots

--- a/tests/test_woffu_api_client.py
+++ b/tests/test_woffu_api_client.py
@@ -1356,27 +1356,6 @@ class TestWoffuAPIStatusSign(BaseWoffuAPITest):
         self.assertIsNone(result)
         mock_post.assert_not_called()
 
-    # @patch.object(WoffuAPIClient, "get")
-    # def test_get_status_multiple_invalid_utc_formats(self, mock_get):
-    #     """get_status handles multiple invalid UtcTime formats."""
-    #     mock_get.return_value.status = 200
-    #     mock_get.return_value.json.return_value = [
-    #         {
-    #             "SignIn": True,
-    #             "TrueDate": "2025-09-12T12:00:00.000",
-    #             "UtcTime": "BAD1",
-    #         },
-    #         {
-    #             "SignIn": False,
-    #             "TrueDate": "2025-09-12T16:00:00.000",
-    #             "UtcTime": "BAD2",
-    #         },
-    #     ]
-
-    #     total, running = self.client.get_status()
-    #     self.assertIsInstance(total, object)
-    #     self.assertFalse(running)
-
     @patch.object(WoffuAPIClient, "get")
     def test_get_status_only_running_clock_last_sign_false(self, mock_get):
         """Test last status being signed out."""

--- a/tests/test_woffu_api_client.py
+++ b/tests/test_woffu_api_client.py
@@ -357,9 +357,12 @@ class TestWoffuAPIDownload(BaseWoffuAPITest):
             },
         ]
 
-        total, running = self.client.get_status(only_running_clock=True)
+        total, running, theoretical_time = self.client.get_status(
+            only_running_clock=True,
+        )
         self.assertIsInstance(total, object)
         self.assertFalse(running)  # Last sign False
+        self.assertIsInstance(theoretical_time, object)
 
     @patch.object(WoffuAPIClient, "get")
     def test_get_status_empty_signs(self, mock_get):
@@ -367,9 +370,10 @@ class TestWoffuAPIDownload(BaseWoffuAPITest):
         mock_get.return_value.status = 200
         mock_get.return_value.json.return_value = []
 
-        total, running = self.client.get_status()
+        total, running, theoretical_time = self.client.get_status()
         self.assertEqual(total.total_seconds(), 0)
         self.assertFalse(running)
+        self.assertEqual(theoretical_time, timedelta(0))
 
     @patch.object(WoffuAPIClient, "get")
     def test_get_status_utc_offset_edge_case(self, mock_get):
@@ -383,9 +387,10 @@ class TestWoffuAPIDownload(BaseWoffuAPITest):
             },
         ]
 
-        total, running = self.client.get_status()
+        total, running, theoretical_time = self.client.get_status()
         self.assertIsInstance(total, object)
         self.assertTrue(running)
+        self.assertEqual(theoretical_time, timedelta(0))
 
     @patch.object(WoffuAPIClient, "get")
     def test_get_diary_hour_types_empty_response(self, mock_get):
@@ -784,6 +789,10 @@ class TestWoffuAPISummaryDiary(BaseWoffuAPITest):
             "date": "2025-09-12",
             "diarySummaryId": 1,
             "diaryHourTypes": [],
+            "workingTimeFormatted": {
+                "resource": "_HoursMinutesFormatted",
+                "values": ['6', '30'],
+            },
         }
         mock_slots.return_value = [
             {
@@ -820,6 +829,10 @@ class TestWoffuAPISummaryDiary(BaseWoffuAPITest):
             "date": "2025-09-12",
             "diarySummaryId": 1,
             "diaryHourTypes": [],
+            "workingTimeFormatted": {
+                "resource": "_HoursMinutesFormatted",
+                "values": ['6', '30'],
+            },
         }
         mock_slots.return_value = [
             {
@@ -848,6 +861,10 @@ class TestWoffuAPISummaryDiary(BaseWoffuAPITest):
             "date": "2025-09-30",
             "diarySummaryId": 1,
             "diaryHourTypes": [],
+            "workingTimeFormatted": {
+                "resource": "_HoursMinutesFormatted",
+                "values": ['6', '30'],
+            },
         }
         mock_slots.return_value = [
             {
@@ -881,6 +898,10 @@ class TestWoffuAPISummaryDiary(BaseWoffuAPITest):
             "date": "2025-09-30",
             "diarySummaryId": 1,
             "diaryHourTypes": [],
+            "workingTimeFormatted": {
+                "resource": "_HoursMinutesFormatted",
+                "values": ['6', '30'],
+            },
         }
         mock_slots.return_value = [
             {
@@ -915,6 +936,10 @@ class TestWoffuAPISummaryDiary(BaseWoffuAPITest):
             "date": "2025-09-12",
             "diarySummaryId": 1,
             "diaryHourTypes": [{"name": "A"}],
+            "workingTimeFormatted": {
+                "resource": "_HoursMinutesFormatted",
+                "values": ['6', '30'],
+            },
         }
         mock_presence.return_value = [diary]
         mock_slots.return_value = []
@@ -932,6 +957,10 @@ class TestWoffuAPISummaryDiary(BaseWoffuAPITest):
             "date": "2025-09-12",
             "diarySummaryId": 1,
             "diaryHourTypes": [],
+            "workingTimeFormatted": {
+                "resource": "_HoursMinutesFormatted",
+                "values": ['6', '30'],
+            },
         }
         mock_presence.return_value = [diary]
         mock_slots.return_value = [
@@ -953,6 +982,10 @@ class TestWoffuAPISummaryDiary(BaseWoffuAPITest):
             "date": "2025-09-12",
             "diarySummaryId": 1,
             "diaryHourTypes": [{"name": "A"}],
+            "workingTimeFormatted": {
+                "resource": "_HoursMinutesFormatted",
+                "values": ['6', '30'],
+            },
         }
         mock_presence.return_value = [diary]
         mock_slots.return_value = []
@@ -972,6 +1005,10 @@ class TestWoffuAPISummaryDiary(BaseWoffuAPITest):
             "date": "2025-09-12",
             "diarySummaryId": 1,
             "diaryHourTypes": [],
+            "workingTimeFormatted": {
+                "resource": "_HoursMinutesFormatted",
+                "values": ['6', '30'],
+            },
         }
         mock_presence.return_value = [diary]
         mock_slots.return_value = [
@@ -985,10 +1022,57 @@ class TestWoffuAPISummaryDiary(BaseWoffuAPITest):
         # Work hours should be 0 because in/out parsing failed
         self.assertAlmostEqual(result["2025-09-12"]["work_hours"], 0)
 
+    @patch.object(WoffuAPIClient, "_get_presence")
+    @patch.object(WoffuAPIClient, "_get_workday_slots")
+    def test_get_summary_report_theoretical_schedule(
+        self, mock_slots, mock_presence,
+    ):
+        """get_summary_report handles diaryHourTypes missing 'hours' key."""
+        diary = {
+            "date": "2025-09-12",
+            "diarySummaryId": 1,
+            "diaryHourTypes": [{"name": "A"}],
+            "workingTimeFormatted": {
+                "resource": "_HoursMinutesFormatted",
+                "values": ['6', '30'],
+            },
+        }
+        mock_presence.return_value = [diary]
+        mock_slots.return_value = []
+        result = self.client.get_summary_report("2025-09-12", "2025-09-12")
+        print(result["2025-09-12"]["theoretical_schedule"])
+        self.assertAlmostEqual(
+            result["2025-09-12"]["theoretical_schedule"], 6.5,
+        )
+
+    @patch.object(WoffuAPIClient, "_get_presence")
+    @patch.object(WoffuAPIClient, "_get_workday_slots")
+    def test_get_summary_report_theoretical_schedule_incorrect_format(
+        self, mock_slots, mock_presence,
+    ):
+        """get_summary_report handles diaryHourTypes missing 'hours' key."""
+        diary = {
+            "date": "2025-09-12",
+            "diarySummaryId": 1,
+            "diaryHourTypes": [{"name": "A"}],
+            "workingTimeFormatted": {
+                "resource": "_InvalidFormatted",
+                "values": ['6', '30'],
+            },
+        }
+        mock_presence.return_value = [diary]
+        mock_slots.return_value = []
+        result = self.client.get_summary_report("2025-09-12", "2025-09-12")
+        print(result["2025-09-12"]["theoretical_schedule"])
+        self.assertAlmostEqual(
+            result["2025-09-12"]["theoretical_schedule"], -1.0,
+        )
 
 # -------------
 # Status & Sign
 # -------------
+
+
 class TestWoffuAPIStatusSign(BaseWoffuAPITest):
     """Test class for WoffuAPIClient Status and Sign calls."""
 
@@ -1074,9 +1158,72 @@ class TestWoffuAPIStatusSign(BaseWoffuAPITest):
             },
         ]
 
-        total, running = self.client.get_status()
+        total, running, theoretical_time = self.client.get_status()
         self.assertIsInstance(total, object)  # timedelta
         self.assertIsInstance(running, bool)
+        self.assertIsInstance(theoretical_time, object)  # timedelta
+
+    @patch.object(WoffuAPIClient, "_get_presence")
+    @patch.object(WoffuAPIClient, "get")
+    def test_get_status_extend(self, mock_get, mock_presence):
+        """Test get_status returns total_time and running_clock."""
+        # Simulate signs with correct UtcTime format
+        mock_get.return_value.status = 200
+        mock_get.return_value.json.return_value = [
+            {
+                "SignIn": True,
+                "TrueDate": "2025-09-12T12:00:00.000",
+                "UtcTime": "12:00:00 +01",
+            },
+        ]
+
+        diary = {
+            "date": "2025-09-12",
+            "diarySummaryId": 1,
+            "diaryHourTypes": [],
+            "workingTimeFormatted": {
+                "resource": "_HoursMinutesFormatted",
+                "values": ['6', '30'],
+            },
+        }
+        mock_presence.return_value = [diary]
+
+        total, running, theoretical_time = self.client.get_status(extend=True)
+        self.assertIsInstance(total, object)  # timedelta
+        self.assertIsInstance(running, bool)
+        self.assertIsInstance(theoretical_time, object)  # timedelta
+        self.assertEqual(theoretical_time, timedelta(hours=6, minutes=30))
+
+    @patch.object(WoffuAPIClient, "_get_presence")
+    @patch.object(WoffuAPIClient, "get")
+    def test_get_status_extend_invalid_format(self, mock_get, mock_presence):
+        """Test get_status returns total_time and running_clock."""
+        # Simulate signs with correct UtcTime format
+        mock_get.return_value.status = 200
+        mock_get.return_value.json.return_value = [
+            {
+                "SignIn": True,
+                "TrueDate": "2025-09-12T12:00:00.000",
+                "UtcTime": "12:00:00 +01",
+            },
+        ]
+
+        diary = {
+            "date": "2025-09-12",
+            "diarySummaryId": 1,
+            "diaryHourTypes": [],
+            "workingTimeFormatted": {
+                "resource": "_InvalidFormatted",
+                "values": ['6', '30'],
+            },
+        }
+        mock_presence.return_value = [diary]
+
+        total, running, theoretical_time = self.client.get_status(extend=True)
+        self.assertIsInstance(total, object)  # timedelta
+        self.assertIsInstance(running, bool)
+        self.assertIsInstance(theoretical_time, object)  # timedelta
+        self.assertEqual(theoretical_time, timedelta())
 
     @patch.object(WoffuAPIClient, "get")
     @patch.object(WoffuAPIClient, "post")
@@ -1095,7 +1242,10 @@ class TestWoffuAPIStatusSign(BaseWoffuAPITest):
             self.client.sign(type="in")
 
     @patch.object(
-        WoffuAPIClient, "get_status", return_value=(timedelta(0), True),
+        WoffuAPIClient, "get_status", return_value=(
+            timedelta(0),
+            True, timedelta(0),
+        ),
     )
     @patch.object(WoffuAPIClient, "post")
     def test_sign_user_already_signed_returns_none(
@@ -1143,7 +1293,7 @@ class TestWoffuAPIStatusSign(BaseWoffuAPITest):
                 "UtcTime": "16:00:00 +01",
             },
         ]
-        _, running = self.client.get_status(only_running_clock=True)
+        _, running, _ = self.client.get_status(only_running_clock=True)
         self.assertFalse(running)
 
     @patch.object(WoffuAPIClient, "get")
@@ -1162,9 +1312,10 @@ class TestWoffuAPIStatusSign(BaseWoffuAPITest):
                 "UtcTime": "BAD2",
             },
         ]
-        total, running = self.client.get_status()
+        total, running, theoretical_time = self.client.get_status()
         self.assertIsInstance(total, timedelta)
         self.assertFalse(running)
+        self.assertIsInstance(theoretical_time, timedelta)
 
 
 class TestWoffuAPICSVExport(BaseWoffuAPITest):
@@ -1181,8 +1332,12 @@ class TestWoffuAPICSVExport(BaseWoffuAPITest):
                     "2025-01-01": {
                         "Extr. a compensar": 0.5,
                         "work_hours": 8.5,
+                        "theoretical_schedule": 8,
                     },
-                    "2025-01-02": {"work_hours": 7.5},
+                    "2025-01-02": {
+                        "work_hours": 7.5,
+                        "theoretical_schedule": 7.5,
+                    },
                 },
                 "",  # from_date
                 "",  # to_date
@@ -1194,8 +1349,12 @@ class TestWoffuAPICSVExport(BaseWoffuAPITest):
                     "2025-01-01": {
                         "Extr. a compensar": 1.5,
                         "work_hours": 9.0,
+                        "theoretical_schedule": 7.5,
                     },
-                    "2025-01-05": {"work_hours": 6.5},
+                    "2025-01-05": {
+                        "work_hours": 6.5,
+                        "theoretical_schedule": 6.5,
+                    },
                 },
                 "2025-01-01",
                 "2025-01-05",
@@ -1236,7 +1395,12 @@ class TestWoffuAPICSVExport(BaseWoffuAPITest):
             csv_content = fake_csv_buffer.read()
 
             if expected_rows:
-                for header in ["Extr. a compensar", "work_hours", "date"]:
+                for header in [
+                    "Extr. a compensar",
+                    "work_hours",
+                    "theoretical_schedule",
+                    "date",
+                ]:
                     self.assertIn(header, csv_content)
                 for row in expected_rows:
                     self.assertIn(row, csv_content)
@@ -1265,7 +1429,11 @@ class TestWoffuAPICSVExport(BaseWoffuAPITest):
     ):
         """Specifically test exporting CSV using a custom delimiter (';')."""
         summary_report = {
-            "2025-01-01": {"Extr. a compensar": 0.5, "work_hours": 8.5},
+            "2025-01-01": {
+                "Extr. a compensar": 0.5,
+                "work_hours": 8.5,
+                "theoretical_schedule": 8,
+            },
         }
         fake_csv_buffer = StringIO()
         mock_open.return_value.__enter__.return_value = fake_csv_buffer
@@ -1281,4 +1449,5 @@ class TestWoffuAPICSVExport(BaseWoffuAPITest):
         self.assertIn("2025-01-01", csv_content)
         self.assertIn("Extr. a compensar", csv_content)
         self.assertIn("work_hours", csv_content)
+        self.assertIn("theoretical_schedule", csv_content)
         mock_logger.info.assert_called_once()

--- a/tests/test_woffu_api_client.py
+++ b/tests/test_woffu_api_client.py
@@ -1027,7 +1027,7 @@ class TestWoffuAPISummaryDiary(BaseWoffuAPITest):
     def test_get_summary_report_theoretical_schedule(
         self, mock_slots, mock_presence,
     ):
-        """get_summary_report handles diaryHourTypes missing 'hours' key."""
+        """get_summary_report handles 'workingTimeFormatted' key."""
         diary = {
             "date": "2025-09-12",
             "diarySummaryId": 1,
@@ -1047,10 +1047,52 @@ class TestWoffuAPISummaryDiary(BaseWoffuAPITest):
 
     @patch.object(WoffuAPIClient, "_get_presence")
     @patch.object(WoffuAPIClient, "_get_workday_slots")
+    def test_get_summary_report_theoretical_schedule_only_hours(
+        self, mock_slots, mock_presence,
+    ):
+        """get_summary_report handles 'workingTimeFormatted' key."""
+        diary = {
+            "date": "2025-09-12",
+            "diarySummaryId": 1,
+            "diaryHourTypes": [{"name": "A"}],
+            "workingTimeFormatted": {
+                "resource": "_HoursFormatted",
+                "values": ['7'],
+            },
+        }
+        mock_presence.return_value = [diary]
+        mock_slots.return_value = []
+        result = self.client.get_summary_report("2025-09-12", "2025-09-12")
+        print(result["2025-09-12"]["theoretical_schedule"])
+        self.assertAlmostEqual(
+            result["2025-09-12"]["theoretical_schedule"], 7,
+        )
+
+    @patch.object(WoffuAPIClient, "_get_presence")
+    @patch.object(WoffuAPIClient, "_get_workday_slots")
+    def test_get_summary_report_theoretical_schedule_weekend(
+        self, mock_slots, mock_presence,
+    ):
+        """get_summary_report handles missing 'workingTimeFormatted' key."""
+        diary = {
+            "date": "2025-09-12",
+            "diarySummaryId": 1,
+            "diaryHourTypes": [{"name": "A"}],
+        }
+        mock_presence.return_value = [diary]
+        mock_slots.return_value = []
+        result = self.client.get_summary_report("2025-09-12", "2025-09-12")
+        print(result["2025-09-12"]["theoretical_schedule"])
+        self.assertAlmostEqual(
+            result["2025-09-12"]["theoretical_schedule"], 0.0,
+        )
+
+    @patch.object(WoffuAPIClient, "_get_presence")
+    @patch.object(WoffuAPIClient, "_get_workday_slots")
     def test_get_summary_report_theoretical_schedule_incorrect_format(
         self, mock_slots, mock_presence,
     ):
-        """get_summary_report handles diaryHourTypes missing 'hours' key."""
+        """get_summary_report handles incorrect 'workingTimeFormatted' key."""
         diary = {
             "date": "2025-09-12",
             "diarySummaryId": 1,
@@ -1193,6 +1235,64 @@ class TestWoffuAPIStatusSign(BaseWoffuAPITest):
         self.assertIsInstance(running, bool)
         self.assertIsInstance(theoretical_time, object)  # timedelta
         self.assertEqual(theoretical_time, timedelta(hours=6, minutes=30))
+
+    @patch.object(WoffuAPIClient, "_get_presence")
+    @patch.object(WoffuAPIClient, "get")
+    def test_get_status_extend_hours(self, mock_get, mock_presence):
+        """Test get_status returns total_time and running_clock."""
+        # Simulate signs with correct UtcTime format
+        mock_get.return_value.status = 200
+        mock_get.return_value.json.return_value = [
+            {
+                "SignIn": True,
+                "TrueDate": "2025-09-12T12:00:00.000",
+                "UtcTime": "12:00:00 +01",
+            },
+        ]
+
+        diary = {
+            "date": "2025-09-12",
+            "diarySummaryId": 1,
+            "diaryHourTypes": [],
+            "workingTimeFormatted": {
+                "resource": "_HoursFormatted",
+                "values": ['7'],
+            },
+        }
+        mock_presence.return_value = [diary]
+
+        total, running, theoretical_time = self.client.get_status(extend=True)
+        self.assertIsInstance(total, object)  # timedelta
+        self.assertIsInstance(running, bool)
+        self.assertIsInstance(theoretical_time, object)  # timedelta
+        self.assertEqual(theoretical_time, timedelta(hours=7))
+
+    @patch.object(WoffuAPIClient, "_get_presence")
+    @patch.object(WoffuAPIClient, "get")
+    def test_get_status_extend_weekend(self, mock_get, mock_presence):
+        """Test get_status returns total_time and running_clock."""
+        # Simulate signs with correct UtcTime format
+        mock_get.return_value.status = 200
+        mock_get.return_value.json.return_value = [
+            {
+                "SignIn": True,
+                "TrueDate": "2025-09-12T12:00:00.000",
+                "UtcTime": "12:00:00 +01",
+            },
+        ]
+
+        diary = {
+            "date": "2025-09-12",
+            "diarySummaryId": 1,
+            "diaryHourTypes": [],
+        }
+        mock_presence.return_value = [diary]
+
+        total, running, theoretical_time = self.client.get_status(extend=True)
+        self.assertIsInstance(total, object)  # timedelta
+        self.assertIsInstance(running, bool)
+        self.assertIsInstance(theoretical_time, object)  # timedelta
+        self.assertEqual(theoretical_time, timedelta(0))
 
     @patch.object(WoffuAPIClient, "_get_presence")
     @patch.object(WoffuAPIClient, "get")


### PR DESCRIPTION
**DESCRIPTION:** This PR addresses the need to report the daily theoretical schedule in `summary-report` and `get -status` commands.

- `summary-report` now adds a new `theoretical_schedule` column with each day's value as float

  ```csv
  Extr. a compensar,date,theoretical_schedule,work_hours
  ,2026-05-01,0.0,0.0
  ,2026-05-02,0.0,0.0
  ,2026-05-03,0.0,0.0
  0.83389,2026-05-04,7.0,7.83389
  0.00444,2026-05-05,7.0,7.00445
  0.12083,2026-05-06,7.0,7.12084
  ,2026-05-07,7.0,6.98945
  0.00278,2026-05-08,7.0,7.00278
  ,2026-05-09,0.0,0.0
  ```

- `get-status` adds a new parameter `--extend` that also shows the theoretical schedule. It has been done like this to keep backwards compatibility and because the theoretical schedule is retrieved through an additional HTTP query, thus keeping it optional.

  ```bash
  $ woffu-cli get-status --extend
  [2026-06-19 10:22:31] INFO woffu_api_client: Hours worked today: 00:23:24
  [2026-06-19 10:22:31] INFO woffu_api_client: You're currently signed in.
  [2026-06-19 10:22:32] INFO woffu_api_client: Theoretical schedule today: 06:30:00
  ```

**RELATED ISSUES:**

- Closes #49 