### PR TITLE
feat: GNOME top-bar applet for one-click sign in / sign out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,117 @@
+# CLAUDE.md
+
+Guidance for Claude Code working in this repository.
+
+## What this project is
+
+A GNOME top-bar applet that lets the user sign in / sign out of Woffu in a couple
+of clicks. It is a **thin front-end over the existing `woffu-cli`**. This is a
+fork of `woffu-client`, and the applet lives **inside the same `woffu_client`
+package** (`src/woffu_client/applet.py`, `core.py`, `status.py`) alongside the
+CLI it drives. The applet does not talk to Woffu directly.
+
+```text
+woffu_client.applet → woffu-cli → Woffu backend
+```
+
+**Core principle: reuse, don't reimplement.** Auth, token caching, and HTTP all
+live in `woffu_client` (the CLI/API client in this same package). The applet only
+adds the GTK front-end and a thin wrapper around the CLI. Never add new HTTP
+requests to Woffu, token handling, or login logic in the applet layers.
+
+## Architecture
+
+Three layers under `src/woffu_client/`, kept strictly separated:
+
+- `core.py` — UI-agnostic wrapper. Exposes `sign_in()`, `sign_out()`,
+  `get_status()`. Shells out to `woffu-cli` (stable contract) and parses its
+  `--json` output via `status.py`. Uses synchronous `subprocess.run`; the applet
+  is responsible for calling these off the main loop (see Conventions). This layer
+  has no GTK imports, so it stays testable and reusable.
+- `status.py` — the `WoffuStatus` model plus `parse_json()` (the `--json` path)
+  and `parse_text()` (keyword-match fallback for older CLIs). Pure functions, no
+  I/O. This is the main thing covered by tests.
+- `applet.py` — GTK 3 + AppIndicator front-end. Builds the indicator and menu,
+  reacts to user clicks, and renders state. No business logic beyond presentation.
+
+When adding a feature, put logic in `core`/`status` and keep `applet` thin.
+
+## Commands
+
+```bash
+# Run the applet (installed entry point, or module form)
+woffu-applet
+python3 -m woffu_client.applet
+
+# One-time setup of the CLI this app drives
+woffu-cli request-credentials
+
+# Verify the CLI contracts the applet depends on
+woffu-cli sign -h
+woffu-cli get-status --json
+
+# Tests (pure logic, no GTK / no network)
+pytest
+
+# Lint / format (match woffu-client's choices: PEP8 via pre-commit)
+ruff check . && ruff format .
+```
+
+## Dependencies
+
+- Runtime: Python 3, `woffu-client`, PyGObject (GTK 3), an AppIndicator binding.
+- AppIndicator binding: import `AyatanaAppIndicator3` first, fall back to legacy
+  `AppIndicator3`. Always keep that fallback — distros ship one or the other.
+- System packages (not pip): `python3-gi` and the GIR for AppIndicator. On Fedora,
+  GNOME also needs the `gnome-shell-extension-appindicator` extension enabled.
+
+## Conventions
+
+- **Never block the GLib main loop.** `core.py` calls the CLI with synchronous
+  `subprocess.run`, so the applet must run every `core` call in a **daemon
+  thread** (`threading.Thread(..., daemon=True)`) and never call it directly from
+  a signal handler or timer. A slow network call must never freeze the GNOME panel.
+- UI updates happen on the main loop. Worker threads marshal results back with
+  `GLib.idle_add` — never touch GTK widgets from a thread.
+- Status is re-checked on a `GLib.timeout_add_seconds` timer and after every
+  sign action, so the icon reflects reality.
+- Icon names come from the Adwaita symbolic set (e.g. `user-available-symbolic`,
+  `user-offline-symbolic`). Don't bundle custom icons unless necessary.
+- Keep `core`/`status` free of any `gi`/GTK imports.
+
+## CLI contracts (verified against the installed version)
+
+Both `woffu-cli` details the applet depends on have been confirmed:
+
+1. **Sign flag** — `woffu-cli sign --sign-type in|out|any` (default `any`).
+   Confirmed via `woffu-cli sign -h`; `core.py` uses `in`/`out`.
+2. **Status output** — `woffu-cli get-status --json` (added in this fork) emits
+   `{"signed_in": bool, "hours_worked": "HH:MM:SS", "theoretical_hours":
+   "HH:MM:SS"|null}` with logs suppressed. `status.parse_json()` consumes it;
+   `status.parse_text()` remains as a keyword-match fallback for older CLIs that
+   lack `--json`.
+
+Other notes:
+
+- First run with no credentials: `get-status` will fail. Surface this as a clear
+  "not configured" state pointing the user to `woffu-cli request-credentials`,
+  rather than crashing.
+- The applet only appears in GNOME if the AppIndicator extension is active.
+
+## Security
+
+- `woffu-client` currently stores credentials/token in a plaintext JSON file
+  (`~/.config/woffu/woffu_auth.json`). Do not copy secrets into this repo, logs,
+  or test fixtures.
+- A planned improvement is to move secrets into the system keyring (`keyring` /
+  libsecret). Prefer that over any new plaintext storage.
+
+## Do / Don't
+
+- ✅ Add features in `core`/`status`; keep `applet` presentational.
+- ✅ Run every `core` CLI call from a daemon thread; marshal back with `GLib.idle_add`.
+- ✅ Write tests for `status.py` and `core.py` logic.
+- ❌ Don't implement Woffu auth or HTTP in the applet layers — drive `woffu-cli`.
+- ❌ Don't call `core` (synchronous `subprocess.run`) directly on the main loop.
+- ❌ Don't touch GTK widgets from a worker thread.
+- ❌ Don't commit credentials, tokens, or real user data.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,10 @@ When adding a feature, put logic in `core`/`status` and keep `applet` thin.
 ## Commands
 
 ```bash
-# Run the applet (installed entry point, or module form)
+# Run the applet (installed entry point, or module form).
+# Needs a Python that has PyGObject: a plain pip venv without system gi fails
+# to import 'gi'. Use the distro python3-gi (e.g. a venv created with
+# --system-site-packages, or the system python).
 woffu-applet
 python3 -m woffu_client.applet
 
@@ -75,8 +78,11 @@ ruff check . && ruff format .
   `GLib.idle_add` — never touch GTK widgets from a thread.
 - Status is re-checked on a `GLib.timeout_add_seconds` timer and after every
   sign action, so the icon reflects reality.
-- Icon names come from the Adwaita symbolic set (e.g. `user-available-symbolic`,
-  `user-offline-symbolic`). Don't bundle custom icons unless necessary.
+- The applet ships a bundled Woffu brand icon at `src/woffu_client/icons/woffu.svg`,
+  loaded with `Indicator.new_with_path`. The same icon is used for every state;
+  the menu's status line conveys signed-in / out / error / not-configured. Swap
+  that file to change the icon (keep it square and simple so it reads at panel
+  size); declare new icon files under `[tool.setuptools.package-data]`.
 - Keep `core`/`status` free of any `gi`/GTK imports.
 
 ## CLI contracts (verified against the installed version)
@@ -97,6 +103,10 @@ Other notes:
   "not configured" state pointing the user to `woffu-cli request-credentials`,
   rather than crashing.
 - The applet only appears in GNOME if the AppIndicator extension is active.
+- Runtime-verified on GNOME: the indicator renders, and Sign in / Sign out drive
+  real Woffu state. Refresh re-queries status too, but because one icon serves
+  all states it produces no icon change — its result shows in the menu's status
+  line the next time the menu is opened (clicking a menu item closes the menu).
 
 ## Security
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,46 @@
+# Applet TODO / backlog
+
+Future work for the Woffu desktop applet, captured from testing and feedback.
+Keep logic in `core`/`status` (with tests) and `applet` presentational — see
+CLAUDE.md.
+
+## Interaction / UI
+
+- [ ] **Single exclusive sign toggle.** Replace the separate "Sign in" /
+      "Sign out" menu items with one toggle — a slider/"circle" dragged
+      left↔right (or pressed) to switch state, since signed-in and signed-out
+      are mutually exclusive. Candidates: `Gtk.Switch` inside a menu item, or a
+      custom widget.
+- [ ] **Drop "Refresh".** Redundant now that status auto-polls every 30s and
+      refreshes after every sign action.
+- [ ] **Show the username** in the menu (nice to have). Needs a way to expose it
+      from the CLI — it already lives in the credentials file / users API.
+- [ ] **Per-state icon tint.** Desaturate/grey the Woffu mark when signed out so
+      the panel reflects state at a glance (signed-in = full colour). Generate a
+      muted variant of `icons/woffu.svg`.
+
+## Notifications
+
+- [ ] **Status-change notification.** Desktop notification after sign in/out (and
+      optionally manual refresh) for visible feedback without opening the menu.
+      (`Gio.Notification` / libnotify.)
+- [ ] **End-of-schedule reminder.** Notify when worked time is within ~30 min of
+      the theoretical daily total (e.g. 06:30). The applet already has both
+      `hours_worked` and `theoretical_hours`, so remaining time is computable.
+      Make the threshold (and on/off) configurable; fire once per day.
+
+## Credentials / onboarding
+
+- [ ] **In-app credentials setup.** A GTK dialog that captures username/password
+      and runs the request-credentials flow on the user's behalf, instead of
+      making them run `woffu-cli request-credentials` in a terminal. Ties into
+      the existing "not configured" state. Security: prefer the system keyring
+      over plaintext (see CLAUDE.md "Security").
+
+## Packaging / delivery (already planned)
+
+- [ ] Ship a `.desktop` autostart file so the applet launches on login.
+- [ ] README install section: system deps (`python3-gi` + AppIndicator GIR),
+      `pip install .[gui]`, the `--system-site-packages` venv note, and enabling
+      the GNOME AppIndicator extension.
+- [ ] Open the PR once the above settle.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,14 @@ dev = [
     "pytest-cov>=6.0.0",
     "pre-commit==4.3.0"
 ]
-
+gui = ["PyGObject"]
 
 [project.urls]
 Homepage = "https://github.com/ProtossGP32/woffu-client"
 
 [project.scripts]
 woffu-cli = "woffu_client.cli:main"
+woffu-applet = "woffu_client.applet:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ package-dir = {"" = "src"}
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+woffu_client = ["icons/*.svg", "icons/*.png"]
+
 [tool.coverage.run]
 branch = true
 omit = [

--- a/src/woffu_client/applet.py
+++ b/src/woffu_client/applet.py
@@ -6,6 +6,7 @@ is never blocked; results are marshalled back via GLib.idle_add.
 """
 from __future__ import annotations
 
+import os
 import threading
 
 import gi
@@ -32,9 +33,10 @@ except ValueError:
 
 _POLL_SECONDS = 30
 
-_ICON_ONLINE = "user-available-symbolic"
-_ICON_OFFLINE = "user-offline-symbolic"
-_ICON_ERROR = "user-busy-symbolic"
+# Bundled Woffu brand icon (icons/woffu.svg). One icon is shown for every
+# state; the menu status line conveys signed-in / out / error / not-configured.
+_ICON_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "icons")
+_ICON_NAME = "woffu"
 
 _NOT_CONFIGURED_LABEL = "Not configured — run woffu-cli request-credentials"
 
@@ -44,10 +46,11 @@ class WoffuApplet:
 
     def __init__(self) -> None:
         """Build the indicator and menu, then start the status poll timer."""
-        self._indicator = AppIndicator3.Indicator.new(
+        self._indicator = AppIndicator3.Indicator.new_with_path(
             "woffu-applet",
-            _ICON_OFFLINE,
+            _ICON_NAME,
             AppIndicator3.IndicatorCategory.APPLICATION_STATUS,
+            _ICON_DIR,
         )
         self._indicator.set_status(AppIndicator3.IndicatorStatus.ACTIVE)
         self._indicator.set_menu(self._build_menu())
@@ -111,19 +114,19 @@ class WoffuApplet:
         self._sign_out_item.set_sensitive(signable)
 
         if not status.configured:
-            self._indicator.set_icon_full(_ICON_ERROR, "not configured")
+            self._indicator.set_icon_full(_ICON_NAME, "Woffu — not configured")
             self._status_label.set_label(status.error or _NOT_CONFIGURED_LABEL)
         elif status.error:
-            self._indicator.set_icon_full(_ICON_ERROR, "error")
+            self._indicator.set_icon_full(_ICON_NAME, "Woffu — error")
             self._status_label.set_label(f"Error: {status.error}")
         elif status.signed_in:
             label = f"Signed in · {status.hours_worked}"
             if status.theoretical_hours:
                 label += f" / {status.theoretical_hours}"
-            self._indicator.set_icon_full(_ICON_ONLINE, "signed in")
+            self._indicator.set_icon_full(_ICON_NAME, "Woffu — signed in")
             self._status_label.set_label(label)
         else:
-            self._indicator.set_icon_full(_ICON_OFFLINE, "signed out")
+            self._indicator.set_icon_full(_ICON_NAME, "Woffu — signed out")
             self._status_label.set_label(f"Signed out · {status.hours_worked}")
         return False  # don't repeat the idle_add
 

--- a/src/woffu_client/applet.py
+++ b/src/woffu_client/applet.py
@@ -36,6 +36,8 @@ _ICON_ONLINE = "user-available-symbolic"
 _ICON_OFFLINE = "user-offline-symbolic"
 _ICON_ERROR = "user-busy-symbolic"
 
+_NOT_CONFIGURED_LABEL = "Not configured — run woffu-cli request-credentials"
+
 
 class WoffuApplet:
     """GNOME indicator that renders Woffu state and drives sign actions."""
@@ -66,13 +68,13 @@ class WoffuApplet:
 
         menu.append(Gtk.SeparatorMenuItem())
 
-        sign_in_item = Gtk.MenuItem(label="Sign in")
-        sign_in_item.connect("activate", self._on_sign_in)
-        menu.append(sign_in_item)
+        self._sign_in_item = Gtk.MenuItem(label="Sign in")
+        self._sign_in_item.connect("activate", self._on_sign_in)
+        menu.append(self._sign_in_item)
 
-        sign_out_item = Gtk.MenuItem(label="Sign out")
-        sign_out_item.connect("activate", self._on_sign_out)
-        menu.append(sign_out_item)
+        self._sign_out_item = Gtk.MenuItem(label="Sign out")
+        self._sign_out_item.connect("activate", self._on_sign_out)
+        menu.append(self._sign_out_item)
 
         menu.append(Gtk.SeparatorMenuItem())
 
@@ -103,7 +105,15 @@ class WoffuApplet:
         GLib.idle_add(self._apply_status, status)
 
     def _apply_status(self, status: WoffuStatus) -> bool:
-        if status.error:
+        # Sign actions only make sense once credentials exist.
+        signable = status.configured
+        self._sign_in_item.set_sensitive(signable)
+        self._sign_out_item.set_sensitive(signable)
+
+        if not status.configured:
+            self._indicator.set_icon_full(_ICON_ERROR, "not configured")
+            self._status_label.set_label(status.error or _NOT_CONFIGURED_LABEL)
+        elif status.error:
             self._indicator.set_icon_full(_ICON_ERROR, "error")
             self._status_label.set_label(f"Error: {status.error}")
         elif status.signed_in:

--- a/src/woffu_client/applet.py
+++ b/src/woffu_client/applet.py
@@ -1,0 +1,151 @@
+"""Woffu GNOME top-bar applet.
+
+GTK 3 + AppIndicator front-end only.  All business logic lives in core.py /
+status.py.  CLI calls are dispatched from daemon threads so the GLib main loop
+is never blocked; results are marshalled back via GLib.idle_add.
+"""
+from __future__ import annotations
+
+import threading
+
+import gi
+
+from . import core
+from .status import WoffuStatus
+
+gi.require_version("Gtk", "3.0")
+
+# Every gi.repository import must run *after* the require_version() calls, so
+# they live inside this try/except: reorder-python-imports leaves nested
+# imports in place, whereas top-level ones get hoisted above the version pin
+# (importing Gtk before pinning would auto-select an arbitrary GTK version).
+# GLib/Gtk are imported first so they exist even if Ayatana is unavailable.
+try:
+    from gi.repository import GLib
+    from gi.repository import Gtk
+    gi.require_version("AyatanaAppIndicator3", "0.1")
+    from gi.repository import AyatanaAppIndicator3 as AppIndicator3
+except ValueError:
+    gi.require_version("AppIndicator3", "0.1")
+    from gi.repository import AppIndicator3
+
+
+_POLL_SECONDS = 30
+
+_ICON_ONLINE = "user-available-symbolic"
+_ICON_OFFLINE = "user-offline-symbolic"
+_ICON_ERROR = "user-busy-symbolic"
+
+
+class WoffuApplet:
+    """GNOME indicator that renders Woffu state and drives sign actions."""
+
+    def __init__(self) -> None:
+        """Build the indicator and menu, then start the status poll timer."""
+        self._indicator = AppIndicator3.Indicator.new(
+            "woffu-applet",
+            _ICON_OFFLINE,
+            AppIndicator3.IndicatorCategory.APPLICATION_STATUS,
+        )
+        self._indicator.set_status(AppIndicator3.IndicatorStatus.ACTIVE)
+        self._indicator.set_menu(self._build_menu())
+
+        self._refresh_status()
+        GLib.timeout_add_seconds(_POLL_SECONDS, self._on_timer)
+
+    # ------------------------------------------------------------------
+    # Menu construction
+    # ------------------------------------------------------------------
+
+    def _build_menu(self) -> Gtk.Menu:
+        menu = Gtk.Menu()
+
+        self._status_label = Gtk.MenuItem(label="Checking status…")
+        self._status_label.set_sensitive(False)
+        menu.append(self._status_label)
+
+        menu.append(Gtk.SeparatorMenuItem())
+
+        sign_in_item = Gtk.MenuItem(label="Sign in")
+        sign_in_item.connect("activate", self._on_sign_in)
+        menu.append(sign_in_item)
+
+        sign_out_item = Gtk.MenuItem(label="Sign out")
+        sign_out_item.connect("activate", self._on_sign_out)
+        menu.append(sign_out_item)
+
+        menu.append(Gtk.SeparatorMenuItem())
+
+        refresh_item = Gtk.MenuItem(label="Refresh")
+        refresh_item.connect("activate", lambda _: self._refresh_status())
+        menu.append(refresh_item)
+
+        quit_item = Gtk.MenuItem(label="Quit")
+        quit_item.connect("activate", lambda _: Gtk.main_quit())
+        menu.append(quit_item)
+
+        menu.show_all()
+        return menu
+
+    # ------------------------------------------------------------------
+    # Status refresh
+    # ------------------------------------------------------------------
+
+    def _on_timer(self) -> bool:
+        self._refresh_status()
+        return True  # keep the timer alive
+
+    def _refresh_status(self) -> None:
+        threading.Thread(target=self._fetch_and_update, daemon=True).start()
+
+    def _fetch_and_update(self) -> None:
+        status = core.get_status()
+        GLib.idle_add(self._apply_status, status)
+
+    def _apply_status(self, status: WoffuStatus) -> bool:
+        if status.error:
+            self._indicator.set_icon_full(_ICON_ERROR, "error")
+            self._status_label.set_label(f"Error: {status.error}")
+        elif status.signed_in:
+            label = f"Signed in · {status.hours_worked}"
+            if status.theoretical_hours:
+                label += f" / {status.theoretical_hours}"
+            self._indicator.set_icon_full(_ICON_ONLINE, "signed in")
+            self._status_label.set_label(label)
+        else:
+            self._indicator.set_icon_full(_ICON_OFFLINE, "signed out")
+            self._status_label.set_label(f"Signed out · {status.hours_worked}")
+        return False  # don't repeat the idle_add
+
+    # ------------------------------------------------------------------
+    # Sign actions
+    # ------------------------------------------------------------------
+
+    def _on_sign_in(self, _: Gtk.MenuItem) -> None:
+        threading.Thread(
+            target=self._do_sign_then_refresh,
+            args=(core.sign_in,),
+            daemon=True,
+        ).start()
+
+    def _on_sign_out(self, _: Gtk.MenuItem) -> None:
+        threading.Thread(
+            target=self._do_sign_then_refresh,
+            args=(core.sign_out,),
+            daemon=True,
+        ).start()
+
+    def _do_sign_then_refresh(self, action: object) -> None:
+        action()
+        status = core.get_status()
+        GLib.idle_add(self._apply_status, status)
+
+
+def main() -> None:
+    """Entry point: start the applet and run the GTK main loop."""
+    WoffuApplet()
+    Gtk.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/woffu_client/cli.py
+++ b/src/woffu_client/cli.py
@@ -183,6 +183,11 @@ def main() -> None:
                     client.get_status(extend=args.extend)
             except Exception as e:
                 logging.disable(logging.NOTSET)
+                if args.json:
+                    # Emit a structured error so the applet can distinguish a
+                    # real failure from a signed-out state, and fail loudly.
+                    print(json.dumps({"error": str(e)}))
+                    sys.exit(1)
                 print(f"❌ Error retrieving status: {e}", file=sys.stderr)
         case "sign":
             try:

--- a/src/woffu_client/cli.py
+++ b/src/woffu_client/cli.py
@@ -6,6 +6,8 @@ CLI tool for woffu-client.
 from __future__ import annotations
 
 import argparse
+import json
+import logging
 import sys
 from pathlib import Path
 
@@ -80,6 +82,12 @@ def main() -> None:
         help="Shows additional info such as theoretical schedule.",
     )
 
+    status_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output status as machine-readable JSON (suppresses log output).",
+    )
+
     # ---- sign ----
     sign_parser = subparsers.add_parser(
         "sign",
@@ -150,8 +158,31 @@ def main() -> None:
                 sys.exit(1)
         case "get-status":
             try:
-                client.get_status(extend=args.extend)
+                if args.json:
+                    logging.disable(logging.INFO)
+                    status_data = client.get_status(extend=True)
+                    total_time, running_clock, theoretical_time = status_data
+                    logging.disable(logging.NOTSET)
+                    h, rem = divmod(int(total_time.total_seconds()), 3600)
+                    m, s = divmod(rem, 60)
+                    theo_str = None
+                    if theoretical_time.total_seconds() > 0:
+                        th, tr = divmod(
+                            int(theoretical_time.total_seconds()), 3600,
+                        )
+                        tm, ts = divmod(tr, 60)
+                        theo_str = f"{th:02d}:{tm:02d}:{ts:02d}"
+                    print(
+                        json.dumps({
+                            "signed_in": running_clock,
+                            "hours_worked": f"{h:02d}:{m:02d}:{s:02d}",
+                            "theoretical_hours": theo_str,
+                        }),
+                    )
+                else:
+                    client.get_status(extend=args.extend)
             except Exception as e:
+                logging.disable(logging.NOTSET)
                 print(f"❌ Error retrieving status: {e}", file=sys.stderr)
         case "sign":
             try:

--- a/src/woffu_client/core.py
+++ b/src/woffu_client/core.py
@@ -1,0 +1,74 @@
+"""Woffu applet core — UI-agnostic CLI wrapper.
+
+Exposes get_status(), sign_in(), sign_out().  No GTK/GLib imports so this
+module remains testable and usable outside the applet.
+
+Callers that care about not blocking a GUI event loop should invoke these
+functions from a background thread and marshal results back to the main thread
+(e.g. via GLib.idle_add in applet.py).
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+
+from .status import parse_json
+from .status import parse_text
+from .status import WoffuStatus
+
+_CLI = "woffu-cli"
+_TIMEOUT = 15
+
+
+def get_status() -> WoffuStatus:
+    """Return the current Woffu sign status and hours worked today."""
+    try:
+        result = subprocess.run(
+            [
+                _CLI, "--non-interactive", "--log-level", "CRITICAL",
+                "get-status", "--json",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT,
+        )
+    except FileNotFoundError:
+        return WoffuStatus(
+            signed_in=False,
+            hours_worked="00:00:00",
+            error="woffu-cli not found — run: woffu-cli request-credentials",
+        )
+    except subprocess.TimeoutExpired:
+        return WoffuStatus(
+            signed_in=False,
+            hours_worked="00:00:00",
+            error="woffu-cli timed out",
+        )
+
+    if result.returncode != 0:
+        msg = (result.stderr.strip() or result.stdout.strip() or "CLI error")
+        return WoffuStatus(signed_in=False, hours_worked="00:00:00", error=msg)
+
+    try:
+        return parse_json(json.loads(result.stdout))
+    except (json.JSONDecodeError, KeyError):
+        # --json flag may be missing on an older installed version; fall back
+        return parse_text(result.stdout + result.stderr)
+
+
+def sign_in() -> None:
+    """Send a sign-in request.  Skips silently if already signed in."""
+    subprocess.run(
+        [_CLI, "--non-interactive", "sign", "--sign-type", "in"],
+        capture_output=True,
+        timeout=_TIMEOUT,
+    )
+
+
+def sign_out() -> None:
+    """Send a sign-out request.  Skips silently if already signed out."""
+    subprocess.run(
+        [_CLI, "--non-interactive", "sign", "--sign-type", "out"],
+        capture_output=True,
+        timeout=_TIMEOUT,
+    )

--- a/src/woffu_client/core.py
+++ b/src/woffu_client/core.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+from pathlib import Path
 
 from .status import parse_json
 from .status import parse_text
@@ -18,6 +19,33 @@ from .status import WoffuStatus
 
 _CLI = "woffu-cli"
 _TIMEOUT = 15
+
+# Where woffu-client caches credentials. Used only to tell a "not configured"
+# state apart from a genuine runtime error — never read or written here.
+_CONFIG_FILE = Path.home() / ".config/woffu/woffu_auth.json"
+_NOT_CONFIGURED_MSG = "Not configured — run: woffu-cli request-credentials"
+
+
+def _is_configured() -> bool:
+    """Return True if the CLI has a credentials file to work with."""
+    return _CONFIG_FILE.exists()
+
+
+def _error_status(message: str) -> WoffuStatus:
+    """Wrap a CLI failure as a status, flagging the not-configured case.
+
+    Crucially this never returns signed_in=False *silently*: a failed status
+    check always carries an error, so the applet can't mistake it for a real
+    signed-out state.
+    """
+    if not _is_configured():
+        return WoffuStatus(
+            signed_in=False,
+            hours_worked="00:00:00",
+            error=_NOT_CONFIGURED_MSG,
+            configured=False,
+        )
+    return WoffuStatus(signed_in=False, hours_worked="00:00:00", error=message)
 
 
 def get_status() -> WoffuStatus:
@@ -36,7 +64,7 @@ def get_status() -> WoffuStatus:
         return WoffuStatus(
             signed_in=False,
             hours_worked="00:00:00",
-            error="woffu-cli not found — run: woffu-cli request-credentials",
+            error="woffu-cli not found — is woffu-client installed?",
         )
     except subprocess.TimeoutExpired:
         return WoffuStatus(
@@ -45,15 +73,27 @@ def get_status() -> WoffuStatus:
             error="woffu-cli timed out",
         )
 
-    if result.returncode != 0:
-        msg = (result.stderr.strip() or result.stdout.strip() or "CLI error")
-        return WoffuStatus(signed_in=False, hours_worked="00:00:00", error=msg)
+    stdout = result.stdout.strip()
 
-    try:
-        return parse_json(json.loads(result.stdout))
-    except (json.JSONDecodeError, KeyError):
-        # --json flag may be missing on an older installed version; fall back
-        return parse_text(result.stdout + result.stderr)
+    # The CLI emits JSON on both success and structured failure ({"error": …}).
+    # Parse it regardless of return code so a failure is never silently read
+    # as a signed-out status.
+    if stdout:
+        try:
+            data = json.loads(stdout)
+        except json.JSONDecodeError:
+            data = None
+        if data is not None:
+            if data.get("error"):
+                return _error_status(str(data["error"]))
+            return parse_json(data)
+
+    if result.returncode != 0:
+        return _error_status(result.stderr.strip() or "woffu-cli error")
+
+    # Return code 0 but non-JSON stdout: older CLI without --json. Fall back to
+    # keyword-matching its text output.
+    return parse_text(result.stdout + result.stderr)
 
 
 def sign_in() -> None:

--- a/src/woffu_client/icons/woffu.svg
+++ b/src/woffu_client/icons/woffu.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <linearGradient id="woffuBg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#3BC1FF"/>
+      <stop offset="1" stop-color="#1E9BFF"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#woffuBg)"/>
+  <g fill="none" stroke="#ffffff" stroke-width="5"
+     stroke-linecap="round" stroke-linejoin="round">
+    <path d="M10 24 q7 -8 14 0 t14 0 t14 0"/>
+    <path d="M10 33 q7 -8 14 0 t14 0 t14 0"/>
+    <path d="M10 42 q7 -8 14 0 t14 0 t14 0"/>
+  </g>
+</svg>

--- a/src/woffu_client/status.py
+++ b/src/woffu_client/status.py
@@ -9,12 +9,18 @@ from dataclasses import dataclass
 
 @dataclass
 class WoffuStatus:
-    """Current Woffu sign state, as rendered by the applet."""
+    """Current Woffu sign state, as rendered by the applet.
+
+    `configured` is False when the CLI has no usable credentials yet, so the
+    applet can show an actionable "run request-credentials" hint instead of a
+    misleading signed-out state.
+    """
 
     signed_in: bool
     hours_worked: str
     theoretical_hours: str | None = None
     error: str | None = None
+    configured: bool = True
 
 
 def parse_json(data: dict) -> WoffuStatus:
@@ -24,6 +30,7 @@ def parse_json(data: dict) -> WoffuStatus:
         hours_worked=data.get("hours_worked", "00:00:00"),
         theoretical_hours=data.get("theoretical_hours"),
         error=data.get("error"),
+        configured=data.get("configured", True),
     )
 
 

--- a/src/woffu_client/status.py
+++ b/src/woffu_client/status.py
@@ -1,0 +1,44 @@
+"""Woffu status model and parsers.
+
+Pure functions and data types — no I/O, no GTK.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class WoffuStatus:
+    """Current Woffu sign state, as rendered by the applet."""
+
+    signed_in: bool
+    hours_worked: str
+    theoretical_hours: str | None = None
+    error: str | None = None
+
+
+def parse_json(data: dict) -> WoffuStatus:
+    """Build a WoffuStatus from a `woffu-cli get-status --json` payload."""
+    return WoffuStatus(
+        signed_in=data.get("signed_in", False),
+        hours_worked=data.get("hours_worked", "00:00:00"),
+        theoretical_hours=data.get("theoretical_hours"),
+        error=data.get("error"),
+    )
+
+
+def parse_text(text: str) -> WoffuStatus:
+    """Fallback: keyword-match the plain-text output of `woffu-cli get-status`.
+
+    Used when the --json flag is unavailable (older CLI versions).
+    Lines look like:
+        [...] INFO woffu_api_client: Hours worked today: HH:MM:SS
+        [...] INFO woffu_api_client: You're currently signed in.
+    """
+    signed_in = "signed in" in text
+    hours_worked = "00:00:00"
+    for line in text.splitlines():
+        if "Hours worked today:" in line:
+            hours_worked = line.split("Hours worked today:")[-1].strip()
+            break
+    return WoffuStatus(signed_in=signed_in, hours_worked=hours_worked)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -50,8 +50,9 @@ class GetStatusTest(unittest.TestCase):
         self.assertTrue(kwargs["capture_output"])
         self.assertTrue(kwargs["text"])
 
+    @patch("src.woffu_client.core._is_configured", return_value=True)
     @patch("src.woffu_client.core.subprocess.run")
-    def test_nonzero_exit_is_error(self, mock_run):
+    def test_nonzero_exit_is_error(self, mock_run, _mock_configured):
         """A non-zero return code surfaces stderr as an error status."""
         mock_run.return_value = _completed(
             stderr="❌ Error retrieving status: boom", returncode=1,
@@ -60,6 +61,43 @@ class GetStatusTest(unittest.TestCase):
         self.assertIsNotNone(status.error)
         self.assertIn("boom", status.error)
         self.assertFalse(status.signed_in)
+        self.assertTrue(status.configured)
+
+    @patch("src.woffu_client.core._is_configured", return_value=True)
+    @patch("src.woffu_client.core.subprocess.run")
+    def test_structured_json_error_surfaced(self, mock_run, _mock_configured):
+        """An {"error": ...} payload (exit 1) is surfaced, not signed-out."""
+        mock_run.return_value = _completed(
+            stdout='{"error": "token expired"}', returncode=1,
+        )
+        status = core.get_status()
+        self.assertEqual(status.error, "token expired")
+        self.assertFalse(status.signed_in)
+        self.assertTrue(status.configured)
+
+    @patch("src.woffu_client.core._is_configured", return_value=True)
+    @patch("src.woffu_client.core.subprocess.run")
+    def test_failure_never_reads_as_signed_out(self, mock_run, _mock_cfg):
+        """A failed check always carries an error (regression: stale token)."""
+        mock_run.return_value = _completed(
+            stdout="", stderr="401 Unauthorized", returncode=1,
+        )
+        status = core.get_status()
+        # The bug was returning signed_in=False with error=None, which the
+        # applet rendered as a real "Signed out" state.
+        self.assertIsNotNone(status.error)
+
+    @patch("src.woffu_client.core._is_configured", return_value=False)
+    @patch("src.woffu_client.core.subprocess.run")
+    def test_not_configured_is_actionable(self, mock_run, _mock_configured):
+        """Missing credentials yield configured=False + an actionable hint."""
+        mock_run.return_value = _completed(
+            stderr="username and password required", returncode=1,
+        )
+        status = core.get_status()
+        self.assertFalse(status.configured)
+        self.assertFalse(status.signed_in)
+        self.assertIn("request-credentials", status.error)
 
     @patch("src.woffu_client.core.subprocess.run")
     def test_cli_not_found(self, mock_run):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,120 @@
+"""Tests for the UI-agnostic Woffu applet core (CLI wrapper)."""
+from __future__ import annotations
+
+import subprocess
+import unittest
+from unittest.mock import patch
+
+import src.woffu_client.core as core
+
+
+def _completed(stdout="", stderr="", returncode=0):
+    """Build a CompletedProcess like subprocess.run returns."""
+    return subprocess.CompletedProcess(
+        args=["woffu-cli"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+class GetStatusTest(unittest.TestCase):
+    """Unit tests for core.get_status()."""
+
+    @patch("src.woffu_client.core.subprocess.run")
+    def test_success_parses_json(self, mock_run):
+        """A clean JSON payload is parsed into a WoffuStatus."""
+        mock_run.return_value = _completed(
+            stdout='{"signed_in": true, "hours_worked": "06:49:39", '
+                   '"theoretical_hours": "06:30:00"}',
+        )
+        status = core.get_status()
+        self.assertTrue(status.signed_in)
+        self.assertEqual(status.hours_worked, "06:49:39")
+        self.assertEqual(status.theoretical_hours, "06:30:00")
+        self.assertIsNone(status.error)
+
+    @patch("src.woffu_client.core.subprocess.run")
+    def test_invokes_cli_with_json_flag(self, mock_run):
+        """get_status drives the CLI non-interactively with --json."""
+        mock_run.return_value = _completed(
+            stdout='{"signed_in": false, "hours_worked": "00:00:00", '
+                   '"theoretical_hours": null}',
+        )
+        core.get_status()
+        args, kwargs = mock_run.call_args
+        cmd = args[0]
+        self.assertIn("get-status", cmd)
+        self.assertIn("--json", cmd)
+        self.assertIn("--non-interactive", cmd)
+        self.assertTrue(kwargs["capture_output"])
+        self.assertTrue(kwargs["text"])
+
+    @patch("src.woffu_client.core.subprocess.run")
+    def test_nonzero_exit_is_error(self, mock_run):
+        """A non-zero return code surfaces stderr as an error status."""
+        mock_run.return_value = _completed(
+            stderr="❌ Error retrieving status: boom", returncode=1,
+        )
+        status = core.get_status()
+        self.assertIsNotNone(status.error)
+        self.assertIn("boom", status.error)
+        self.assertFalse(status.signed_in)
+
+    @patch("src.woffu_client.core.subprocess.run")
+    def test_cli_not_found(self, mock_run):
+        """A missing woffu-cli becomes a clear 'not found' error."""
+        mock_run.side_effect = FileNotFoundError()
+        status = core.get_status()
+        self.assertIsNotNone(status.error)
+        self.assertIn("woffu-cli not found", status.error)
+
+    @patch("src.woffu_client.core.subprocess.run")
+    def test_timeout(self, mock_run):
+        """A CLI timeout becomes a timeout error status."""
+        mock_run.side_effect = subprocess.TimeoutExpired(
+            cmd="woffu-cli", timeout=15,
+        )
+        status = core.get_status()
+        self.assertIsNotNone(status.error)
+        self.assertIn("timed out", status.error)
+
+    @patch("src.woffu_client.core.subprocess.run")
+    def test_falls_back_to_text_on_bad_json(self, mock_run):
+        """Non-JSON stdout (older CLI) falls back to text parsing."""
+        mock_run.return_value = _completed(
+            stdout="Hours worked today: 06:44:58\n"
+                   "You're currently signed in.\n",
+        )
+        status = core.get_status()
+        self.assertTrue(status.signed_in)
+        self.assertEqual(status.hours_worked, "06:44:58")
+        self.assertIsNone(status.error)
+
+
+class SignTest(unittest.TestCase):
+    """Unit tests for core.sign_in() / core.sign_out()."""
+
+    @patch("src.woffu_client.core.subprocess.run")
+    def test_sign_in_command(self, mock_run):
+        """sign_in sends --sign-type in."""
+        mock_run.return_value = _completed()
+        core.sign_in()
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("sign", cmd)
+        self.assertIn("--sign-type", cmd)
+        self.assertIn("in", cmd)
+
+    @patch("src.woffu_client.core.subprocess.run")
+    def test_sign_out_command(self, mock_run):
+        """sign_out sends --sign-type out."""
+        mock_run.return_value = _completed()
+        core.sign_out()
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("sign", cmd)
+        self.assertIn("--sign-type", cmd)
+        self.assertIn("out", cmd)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,96 @@
+"""Tests for the Woffu status model and parsers."""
+from __future__ import annotations
+
+import unittest
+
+from src.woffu_client.status import parse_json
+from src.woffu_client.status import parse_text
+from src.woffu_client.status import WoffuStatus
+
+
+class ParseJsonTest(unittest.TestCase):
+    """Unit tests for status.parse_json()."""
+
+    def test_full_payload(self):
+        """A complete --json payload maps onto every field."""
+        status = parse_json({
+            "signed_in": True,
+            "hours_worked": "06:49:39",
+            "theoretical_hours": "06:30:00",
+        })
+        self.assertTrue(status.signed_in)
+        self.assertEqual(status.hours_worked, "06:49:39")
+        self.assertEqual(status.theoretical_hours, "06:30:00")
+        self.assertIsNone(status.error)
+
+    def test_null_theoretical(self):
+        """A null theoretical_hours stays None."""
+        status = parse_json({
+            "signed_in": False,
+            "hours_worked": "00:00:00",
+            "theoretical_hours": None,
+        })
+        self.assertFalse(status.signed_in)
+        self.assertIsNone(status.theoretical_hours)
+
+    def test_missing_keys_use_defaults(self):
+        """An empty dict falls back to safe defaults, not a crash."""
+        status = parse_json({})
+        self.assertFalse(status.signed_in)
+        self.assertEqual(status.hours_worked, "00:00:00")
+        self.assertIsNone(status.theoretical_hours)
+        self.assertIsNone(status.error)
+
+    def test_error_key_is_carried(self):
+        """An error key is surfaced on the model."""
+        status = parse_json({"error": "not configured"})
+        self.assertEqual(status.error, "not configured")
+
+
+class ParseTextTest(unittest.TestCase):
+    """Unit tests for the status.parse_text() fallback."""
+
+    SIGNED_IN = (
+        "[2026-06-29 17:14:58] INFO woffu_api_client: "
+        "Hours worked today: 06:44:58\n"
+        "[2026-06-29 17:14:58] INFO woffu_api_client: "
+        "You're currently signed in.\n"
+    )
+    SIGNED_OUT = (
+        "[2026-06-29 18:00:00] INFO woffu_api_client: "
+        "Hours worked today: 08:00:00\n"
+        "[2026-06-29 18:00:00] INFO woffu_api_client: "
+        "You're currently signed out.\n"
+    )
+
+    def test_signed_in_text(self):
+        """'signed in' is detected and hours are extracted."""
+        status = parse_text(self.SIGNED_IN)
+        self.assertTrue(status.signed_in)
+        self.assertEqual(status.hours_worked, "06:44:58")
+
+    def test_signed_out_text(self):
+        """'signed out' is not mistaken for signed in."""
+        status = parse_text(self.SIGNED_OUT)
+        self.assertFalse(status.signed_in)
+        self.assertEqual(status.hours_worked, "08:00:00")
+
+    def test_no_hours_line_defaults(self):
+        """Absent an hours line, hours_worked stays at the default."""
+        status = parse_text("some unrelated output\n")
+        self.assertFalse(status.signed_in)
+        self.assertEqual(status.hours_worked, "00:00:00")
+
+
+class WoffuStatusTest(unittest.TestCase):
+    """Unit tests for the WoffuStatus dataclass defaults."""
+
+    def test_optional_fields_default(self):
+        """theoretical_hours and error default to None."""
+        status = WoffuStatus(signed_in=True, hours_worked="01:00:00")
+        self.assertIsNone(status.theoretical_hours)
+        self.assertIsNone(status.error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -46,6 +46,11 @@ class ParseJsonTest(unittest.TestCase):
         status = parse_json({"error": "not configured"})
         self.assertEqual(status.error, "not configured")
 
+    def test_configured_defaults_true(self):
+        """A payload without a configured key is treated as configured."""
+        status = parse_json({"signed_in": True, "hours_worked": "01:00:00"})
+        self.assertTrue(status.configured)
+
 
 class ParseTextTest(unittest.TestCase):
     """Unit tests for the status.parse_text() fallback."""
@@ -86,10 +91,11 @@ class WoffuStatusTest(unittest.TestCase):
     """Unit tests for the WoffuStatus dataclass defaults."""
 
     def test_optional_fields_default(self):
-        """theoretical_hours and error default to None."""
+        """theoretical_hours/error default to None and configured to True."""
         status = WoffuStatus(signed_in=True, hours_worked="01:00:00")
         self.assertIsNone(status.theoretical_hours)
         self.assertIsNone(status.error)
+        self.assertTrue(status.configured)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #52

## Summary

- Add `status.py` — `WoffuStatus` dataclass + `parse_json()` / `parse_text()` parsers (pure, no I/O, no GTK)
- Add `core.py` — UI-agnostic CLI wrapper (`get_status`, `sign_in`, `sign_out`); shells out to `woffu-cli`, never talks to Woffu directly
- Add `applet.py` — GTK 3 + AppIndicator front-end; all CLI calls run in daemon threads, results marshalled back via `GLib.idle_add`
- Add `icons/woffu.svg` — bundled Woffu brand icon loaded via `Indicator.new_with_path`
- Extend `woffu-cli get-status` with a `--json` flag emitting `{signed_in, hours_worked, theoretical_hours}` with logs suppressed
- Register `woffu-applet` entry point and a `gui` extra (`PyGObject`) in `pyproject.toml`

## Acceptance criteria

- [x] `pip install .[gui]` installs the applet and its GTK dependencies
  — `2fce6f2` (`gui` extra in pyproject.toml), `c65e6fe` (icon package-data)
- [x] `woffu-applet` starts and the indicator icon appears in the GNOME top bar
  — `2fce6f2` (entry point + AppIndicator setup), `c65e6fe` (bundled SVG icon)
- [x] Status line correctly shows signed-in / signed-out state with `hours_worked`; `theoretical_hours` shown when available
  — `2fce6f2` (`_apply_status` rendering), `3d8ccf6` (structured error/configured field)
- [x] Sign in / Sign out drive real Woffu state via `woffu-cli sign --sign-type in|out`
  — `2fce6f2` (`core.sign_in` / `core.sign_out`, `_on_sign_in` / `_on_sign_out` handlers)
- [x] Not-configured state is shown clearly with an actionable hint; sign items are greyed out
  — `3d8ccf6` (`_is_configured()` check, `WoffuStatus.configured`, `_apply_status` disabling sign items)
- [x] CLI errors are shown in the status line (no crash)
  — `3d8ccf6` (`_error_status()`, structured `{"error": …}` JSON from CLI, `Error: …` label in applet)
- [x] Panel never freezes during a slow network call
  — `2fce6f2` (every `core` call dispatched via `threading.Thread(..., daemon=True)`)
- [x] `pytest` passes — unit tests for `status.py` and `core.py` (no GTK/network needed)
  — `2fce6f2` (16 tests), `3d8ccf6` (+4 regression tests) → **162 tests passing**
- [x] Code coverage for new modules ≥ 90%
  — `core.py` **98%**, `status.py` **100%** (verified locally)
- [x] `pre-commit run --all-files` passes with no errors
  — verified locally: all hooks pass (trailing commas, autopep8, flake8, markdownlint, …)
- [x] No credentials or real user data committed
  — no `~/.config/woffu/` content or token values in any commit

## Test plan

- [ ] `pip install -e .[gui]` in a venv with `--system-site-packages` (needs distro `python3-gi`)
- [ ] `woffu-applet` — confirm icon appears in GNOME top bar
- [ ] Sign in → status line updates to `Signed in · HH:MM:SS`
- [ ] Sign out → status line updates to `Signed out · HH:MM:SS`
- [ ] Remove `~/.config/woffu/woffu_auth.json` → confirm "Not configured" hint and greyed-out sign items
- [ ] `pytest` — all 162 tests pass
- [ ] `pre-commit run --all-files` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)