### PR TITLE
feat: add GNOME app-grid launcher entry for woffu-applet

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,43 @@ woffu-applet
 python3 -m woffu_client.applet
 ```
 
+##### Launcher entry — GNOME "Activities" app grid
+
+`pip install`ing `woffu-client` does not register a launcher entry — GNOME
+only shows a manually installed `.desktop` file in the "Activities" app
+grid, it doesn't scan `PATH` for scripts. This step is optional (it only
+affects whether you can *launch* `woffu-applet` by clicking its icon
+instead of typing the command) and is unrelated to autostart-at-login,
+which isn't implemented yet (see `TODO.md`).
+
+The package ships its `.desktop` file and icon as package data, so you can
+register them for your user account — no root, no cloning this repo. Run
+this with the same Python/venv you installed `woffu-client` into:
+
+```bash
+# Resolve the installed package's on-disk .desktop file and icon
+DESKTOP_FILE=$(python3 -c "from importlib.resources import files; print(files('woffu_client') / 'data' / 'woffu-applet.desktop')")
+ICON_FILE=$(python3 -c "from importlib.resources import files; print(files('woffu_client') / 'icons' / 'woffu.svg')")
+
+# Register the launcher entry for your user only
+xdg-desktop-menu install --mode user "$DESKTOP_FILE"
+
+# Install the icon into the user icon theme so Icon=woffu resolves
+# (xdg-icon-resource only accepts .png/.xpm, so SVGs go straight into
+# the hicolor theme's scalable bucket instead)
+install -Dm644 "$ICON_FILE" ~/.local/share/icons/hicolor/scalable/apps/woffu.svg
+gtk-update-icon-cache -f -t ~/.local/share/icons/hicolor 2>/dev/null || true
+```
+
+Open "Activities" and search for "Woffu" — the entry should appear (usually
+within a few seconds, no logout needed) and launch `woffu-applet`. To
+remove it again:
+
+```bash
+rm ~/.local/share/applications/woffu-applet.desktop
+rm ~/.local/share/icons/hicolor/scalable/apps/woffu.svg
+```
+
 ## Usage
 
 ```bash

--- a/TODO.md
+++ b/TODO.md
@@ -56,6 +56,11 @@ costly in practice (e.g. rate limiting):
 - [x] README install section: system deps (`python3-gi` + AppIndicator GIR),
       `pip install .[gui]`, the `--system-site-packages` venv note, and enabling
       the GNOME AppIndicator extension.
+- [x] Ship a `.desktop` **launcher** entry (GNOME "Activities" app grid)
+      plus an icon-theme install path, documented in README — usable by
+      plain `pip install`s too, not just a future `.deb`/`.rpm`. Distinct
+      from the autostart item above: no autostart keys added, different
+      XDG location (`~/.local/share/applications/`, not `~/.config/autostart/`).
 
 ### Self-hosted, no-Python-env installable (separate initiative)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ package-dir = {"" = "src"}
 where = ["src"]
 
 [tool.setuptools.package-data]
-woffu_client = ["icons/*.svg", "icons/*.png"]
+woffu_client = ["icons/*.svg", "icons/*.png", "data/*.desktop"]
 
 [tool.coverage.run]
 branch = true

--- a/src/woffu_client/data/woffu-applet.desktop
+++ b/src/woffu_client/data/woffu-applet.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=Woffu
+Comment=Sign in or out of Woffu in a couple of clicks
+Exec=woffu-applet
+Icon=woffu
+Terminal=false
+Categories=Utility;
+DBusActivatable=false
+StartupNotify=false

--- a/tests/test_desktop_entry.py
+++ b/tests/test_desktop_entry.py
@@ -1,0 +1,49 @@
+"""Tests for the packaged woffu-applet.desktop launcher entry."""
+from __future__ import annotations
+
+import configparser
+import unittest
+from pathlib import Path
+
+_DESKTOP_FILE = (
+    Path(__file__).resolve().parent.parent / "src" / "woffu_client" /
+    "data" / "woffu-applet.desktop"
+)
+
+
+class DesktopEntryTest(unittest.TestCase):
+    """Unit tests for the shipped woffu-applet.desktop file."""
+
+    def setUp(self):
+        """Parse the .desktop file once per test."""
+        self.assertTrue(
+            _DESKTOP_FILE.is_file(), f"missing {_DESKTOP_FILE}",
+        )
+        parser = configparser.ConfigParser()
+        parser.optionxform = str
+        parser.read(_DESKTOP_FILE)
+        self.entry = parser["Desktop Entry"]
+
+    def test_required_keys_match_agreed_values(self):
+        """Keys agreed on issue #65 are present with the right values."""
+        self.assertEqual(self.entry["Type"], "Application")
+        self.assertEqual(self.entry["Version"], "1.0")
+        self.assertEqual(self.entry["Name"], "Woffu")
+        self.assertEqual(self.entry["Exec"], "woffu-applet")
+        self.assertEqual(self.entry["Icon"], "woffu")
+        self.assertEqual(self.entry["Terminal"], "false")
+        self.assertEqual(self.entry["Categories"], "Utility;")
+        self.assertEqual(self.entry["DBusActivatable"], "false")
+        self.assertEqual(self.entry["StartupNotify"], "false")
+
+    def test_comment_is_non_empty(self):
+        """A Comment is present so app grids/tooltips show a description."""
+        self.assertTrue(self.entry["Comment"].strip())
+
+    def test_omits_autostart_keys(self):
+        """No autostart keys: a launcher entry, not autostart (TODO.md)."""
+        self.assertNotIn("X-GNOME-Autostart-enabled", self.entry)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- First sub-PR of issue #65's revised plan: adds a `.desktop` launcher
  entry + icon-theme install path for `woffu-applet`, so it can be
  registered in GNOME's "Activities" app grid.
- Shipped as package data (`src/woffu_client/data/woffu-applet.desktop`,
  declared in `pyproject.toml`), so it's reachable by a plain
  `pip install woffu-client` — not just a future `.deb`/`.rpm`. No CI/fpm
  work here; that's later steps in #65.
- Scoped to a launcher entry only, **not** autostart-at-login (separate,
  still-open `TODO.md` item, untouched by this PR).

## Two things flagged for review (also posted to #65 before implementing)

- The plan originally said this file would live at top-level
  `data/woffu-applet.desktop`. That path doesn't ship inside the wheel, so
  I moved it to `src/woffu_client/data/` instead (same `package-data`
  mechanism `icons/` already uses) — otherwise a pip-only install would
  have nothing local to point `xdg-desktop-menu` at.
- Added a `StartupNotify=false` key beyond the previously-agreed set:
  tray/indicator apps never map a window, so without it GNOME can show an
  indefinite "launching…" spinner. Happy to drop it if you'd rather keep
  the original key list as-is.

## Test plan

- [x] `pytest -v --maxfail=1 --disable-warnings tests` — 184 passed,
      including new `tests/test_desktop_entry.py`
- [x] `pre-commit run --all-files` — clean
- [x] Staged a real package install (`pip install --target=... .`) and
      confirmed the `.desktop` file + icon land under `woffu_client/data/`
      and `woffu_client/icons/`
- [x] `desktop-file-validate` on the shipped file — passes silently
- [x] `xdg-desktop-menu install --mode user` — registers the entry at
      `~/.local/share/applications/woffu-applet.desktop`; icon installed
      to `~/.local/share/icons/hicolor/scalable/apps/woffu.svg`; both
      cleaned up after verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)